### PR TITLE
Cleaned up tests for clang/LLVM conformance

### DIFF
--- a/AnimTest/Game.cpp
+++ b/AnimTest/Game.cpp
@@ -22,9 +22,9 @@
 
 namespace
 {
-    const float row0 = 2.f;
-    const float row1 = 0.f;
-    const float row2 = -2.f;
+    constexpr float row0 = 2.f;
+    constexpr float row1 = 0.f;
+    constexpr float row2 = -2.f;
 }
 
 extern void ExitGame() noexcept;
@@ -333,7 +333,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/AnimTest/pch.h
+++ b/AnimTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/Audio3DTest/Game.cpp
+++ b/Audio3DTest/Game.cpp
@@ -33,15 +33,15 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const X3DAUDIO_CONE Listener_DirectionalCone = { X3DAUDIO_PI*5.0f/6.0f, X3DAUDIO_PI*11.0f/6.0f, 1.0f, 0.75f, 0.0f, 0.25f, 0.708f, 1.0f };
+    constexpr X3DAUDIO_CONE Listener_DirectionalCone = { X3DAUDIO_PI*5.0f/6.0f, X3DAUDIO_PI*11.0f/6.0f, 1.0f, 0.75f, 0.0f, 0.25f, 0.708f, 1.0f };
 
-    const X3DAUDIO_CONE Emitter_DirectionalCone = { 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1.f };
+    constexpr X3DAUDIO_CONE Emitter_DirectionalCone = { 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1.f };
 
-    const X3DAUDIO_DISTANCE_CURVE_POINT Emitter_LFE_CurvePoints[3] = { 0.0f, 1.0f, 0.25f, 0.0f, 1.0f, 0.0f };
-    const X3DAUDIO_DISTANCE_CURVE       Emitter_LFE_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*) &Emitter_LFE_CurvePoints[0], 3 };
+    constexpr X3DAUDIO_DISTANCE_CURVE_POINT Emitter_LFE_CurvePoints[3] = { { 0.0f, 1.0f }, { 0.25f, 0.0f}, { 1.0f, 0.0f } };
+    constexpr X3DAUDIO_DISTANCE_CURVE       Emitter_LFE_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*) &Emitter_LFE_CurvePoints[0], 3 };
 
-    const X3DAUDIO_DISTANCE_CURVE_POINT Emitter_Reverb_CurvePoints[3] = { 0.0f, 0.5f, 0.75f, 1.0f, 1.0f, 0.0f };
-    const X3DAUDIO_DISTANCE_CURVE       Emitter_Reverb_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*) &Emitter_Reverb_CurvePoints[0], 3 };
+    constexpr X3DAUDIO_DISTANCE_CURVE_POINT Emitter_Reverb_CurvePoints[3] = { { 0.0f, 0.5f}, { 0.75f, 1.0f }, { 1.0f, 0.0f } };
+    constexpr X3DAUDIO_DISTANCE_CURVE       Emitter_Reverb_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*) &Emitter_Reverb_CurvePoints[0], 3 };
 
     void SetDeviceString(_In_ AudioEngine* engine, _Out_writes_(maxsize) wchar_t* deviceStr, size_t maxsize)
     {
@@ -479,7 +479,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 14, 0 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 14.f, 0.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/Audio3DTest/pch.h
+++ b/Audio3DTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -37,6 +43,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -72,6 +82,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/BasicAudioTest/BasicAudioTest.cpp
+++ b/BasicAudioTest/BasicAudioTest.cpp
@@ -96,20 +96,20 @@ namespace
         {
             if (wfx->cbSize < (sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)))
             {
-                printf("\tEXTENSIBLE, %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                printf("\tEXTENSIBLE, %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                     wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
                 printf("\tERROR: Invalid WAVE_FORMAT_EXTENSIBLE\n");
             }
             else
             {
-                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 };
+                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 } };
 
                 auto wfex = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(wfx);
 
                 if (memcmp(reinterpret_cast<const BYTE*>(&wfex->SubFormat) + sizeof(DWORD),
                     reinterpret_cast<const BYTE*>(&s_wfexBase) + sizeof(DWORD), sizeof(GUID) - sizeof(DWORD)) != 0)
                 {
-                    printf("\tEXTENSIBLE, %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                    printf("\tEXTENSIBLE, %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                         wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
                     printf("\tERROR: Unknown EXTENSIBLE SubFormat {%8.8lX-%4.4X-%4.4X-%2.2X%2.2X-%2.2X%2.2X%2.2X%2.2X%2.2X%2.2X}\n",
                         wfex->SubFormat.Data1, wfex->SubFormat.Data2, wfex->SubFormat.Data3,
@@ -118,17 +118,17 @@ namespace
                 }
                 else
                 {
-                    printf("\tEXTENSIBLE %s (%u), %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                    printf("\tEXTENSIBLE %s (%lu), %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                         GetFormatTagName(wfex->SubFormat.Data1), wfex->SubFormat.Data1,
                         wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
-                    printf("\t\t%u samples per block, %u valid bps, %u channel mask",
+                    printf("\t\t%u samples per block, %u valid bps, %lu channel mask",
                         wfex->Samples.wSamplesPerBlock, wfex->Samples.wValidBitsPerSample, wfex->dwChannelMask);
                 }
             }
         }
         else
         {
-            printf("\t%s (%u), %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+            printf("\t%s (%u), %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                 GetFormatTagName(wfx->wFormatTag), wfx->wFormatTag,
                 wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
         }
@@ -228,7 +228,7 @@ int __cdecl main()
             if ( output.Format.nChannels != testwfx.nChannels
                  || output.Format.nSamplesPerSec != testwfx.nSamplesPerSec )
             {
-                printf("ERROR: Output format rate %u, channels %u was not expected\n", output.Format.nSamplesPerSec, output.Format.nChannels );
+                printf("ERROR: Output format rate %lu, channels %u was not expected\n", output.Format.nSamplesPerSec, output.Format.nChannels );
                 dump_wfx( reinterpret_cast<const WAVEFORMATEX*>( &output ) );
                 return 1;
             }
@@ -275,7 +275,7 @@ int __cdecl main()
         default:                        speakerConfig = "(unknown)"; break;
         }
 
-        printf("\tOutput format rate %u, channels %u, %s (%08X)\n", output.Format.nSamplesPerSec, output.Format.nChannels, speakerConfig, output.dwChannelMask );
+        printf("\tOutput format rate %lu, channels %u, %s (%08lX)\n", output.Format.nSamplesPerSec, output.Format.nChannels, speakerConfig, output.dwChannelMask );
     }
 
     if ( !audEngine->IsAudioDevicePresent() )

--- a/D3D11Test/pch.h
+++ b/D3D11Test/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/DGSLTest/Game.cpp
+++ b/DGSLTest/Game.cpp
@@ -30,9 +30,9 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const float row0 = 2.f;
-    const float row1 = 0.f;
-    const float row2 = -2.f;
+    constexpr float row0 = 2.f;
+    constexpr float row1 = 0.f;
+    constexpr float row2 = -2.f;
 }
 
 Game::Game() noexcept(false)
@@ -437,7 +437,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/DGSLTest/pch.h
+++ b/DGSLTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/DynamicAudioTest/DynamicAudioTest.cpp
+++ b/DynamicAudioTest/DynamicAudioTest.cpp
@@ -87,20 +87,20 @@ namespace
         {
             if (wfx->cbSize < (sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)))
             {
-                printf("\tEXTENSIBLE, %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                printf("\tEXTENSIBLE, %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                     wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
                 printf("\tERROR: Invalid WAVE_FORMAT_EXTENSIBLE\n");
             }
             else
             {
-                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 };
+                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 } };
 
                 auto wfex = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(wfx);
 
                 if (memcmp(reinterpret_cast<const BYTE*>(&wfex->SubFormat) + sizeof(DWORD),
                     reinterpret_cast<const BYTE*>(&s_wfexBase) + sizeof(DWORD), sizeof(GUID) - sizeof(DWORD)) != 0)
                 {
-                    printf("\tEXTENSIBLE, %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                    printf("\tEXTENSIBLE, %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                         wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
                     printf("\tERROR: Unknown EXTENSIBLE SubFormat {%8.8lX-%4.4X-%4.4X-%2.2X%2.2X-%2.2X%2.2X%2.2X%2.2X%2.2X%2.2X}\n",
                         wfex->SubFormat.Data1, wfex->SubFormat.Data2, wfex->SubFormat.Data3,
@@ -109,17 +109,17 @@ namespace
                 }
                 else
                 {
-                    printf("\tEXTENSIBLE %s (%u), %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                    printf("\tEXTENSIBLE %s (%lu), %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                         GetFormatTagName(wfex->SubFormat.Data1), wfex->SubFormat.Data1,
                         wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
-                    printf("\t\t%u samples per block, %u valid bps, %u channel mask",
+                    printf("\t\t%u samples per block, %u valid bps, %lu channel mask",
                         wfex->Samples.wSamplesPerBlock, wfex->Samples.wValidBitsPerSample, wfex->dwChannelMask);
                 }
             }
         }
         else
         {
-            printf("\t%s (%u), %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+            printf("\t%s (%u), %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                 GetFormatTagName(wfx->wFormatTag), wfx->wFormatTag,
                 wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
         }
@@ -268,7 +268,7 @@ int __cdecl main()
         default:                        speakerConfig = "(unknown)"; break;
         }
 
-        printf("\tOutput format rate %u, channels %u, %s (%08X)\n", output.Format.nSamplesPerSec, output.Format.nChannels, speakerConfig, output.dwChannelMask );
+        printf("\tOutput format rate %lu, channels %u, %s (%08lX)\n", output.Format.nSamplesPerSec, output.Format.nChannels, speakerConfig, output.dwChannelMask );
     }
 
     if ( !audEngine->IsAudioDevicePresent() )

--- a/EffectsTest/Game.cpp
+++ b/EffectsTest/Game.cpp
@@ -28,26 +28,26 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const float rowA = -2.f;
-    const float row0 = 2.5f;
-    const float row1 = 1.5f;
-    const float row2 = 0.5f;
-    const float row3 = 0.f;
-    const float row4 = -0.5f;
-    const float row5 = -1.5f;
-    const float row6 = -2.5f;
+    constexpr float rowA = -2.f;
+    constexpr float row0 = 2.5f;
+    constexpr float row1 = 1.5f;
+    constexpr float row2 = 0.5f;
+    constexpr float row3 = 0.f;
+    constexpr float row4 = -0.5f;
+    constexpr float row5 = -1.5f;
+    constexpr float row6 = -2.5f;
 
-    const float colA = -5.f;
-    const float col0 = -4.f;
-    const float col1 = -3.f;
-    const float col2 = -2.f;
-    const float col3 = -1.f;
-    const float col4 = 0.f;
-    const float col5 = 1.f;
-    const float col6 = 2.f;
-    const float col7 = 3.f;
-    const float col8 = 4.f;
-    const float col9 = 5.f;
+    constexpr float colA = -5.f;
+    constexpr float col0 = -4.f;
+    constexpr float col1 = -3.f;
+    constexpr float col2 = -2.f;
+    constexpr float col3 = -1.f;
+    constexpr float col4 = 0.f;
+    constexpr float col5 = 1.f;
+    constexpr float col6 = 2.f;
+    constexpr float col7 = 3.f;
+    constexpr float col8 = 4.f;
+    constexpr float col9 = 5.f;
 
     struct TestVertex
     {
@@ -56,7 +56,7 @@ namespace
             XMStoreFloat3(&this->position, position);
             XMStoreFloat3(&this->normal, normal);
             XMStoreFloat2(&this->textureCoordinate, textureCoordinate);
-            XMStoreFloat2(&this->textureCoordinate2, textureCoordinate * 3);
+            XMStoreFloat2(&this->textureCoordinate2, XMVectorScale(textureCoordinate, 3));
             XMStoreUByte4(&this->blendIndices, XMVectorSet(0, 1, 2, 3));
 
             float u = XMVectorGetX(textureCoordinate) - 0.5f;
@@ -112,7 +112,7 @@ namespace
 
         for (int i = 0; i < 16; i++)
         {
-            controlPoints[i] = TeapotControlPoints[patch.indices[i]] * scale;
+            controlPoints[i] = XMVectorMultiply(TeapotControlPoints[patch.indices[i]], scale);
         }
 
         // Create the index data.
@@ -135,7 +135,9 @@ namespace
         VertexCollection vertices;
         IndexCollection indices;
 
-        for (int i = 0; i < sizeof(TeapotPatches) / sizeof(TeapotPatches[0]); i++)
+        XMVECTOR negateXZ = XMVectorMultiply(g_XMNegateX, g_XMNegateZ);
+
+        for (size_t i = 0; i < sizeof(TeapotPatches) / sizeof(TeapotPatches[0]); i++)
         {
             TeapotPatch const& patch = TeapotPatches[i];
 
@@ -150,7 +152,7 @@ namespace
                 // handle or spout) are also symmetrical from front to back, so
                 // we tessellate them four times, mirroring in Z as well as X.
                 TessellatePatch(vertices, indices, patch, g_XMNegateZ, true);
-                TessellatePatch(vertices, indices, patch, g_XMNegateX * g_XMNegateZ, false);
+                TessellatePatch(vertices, indices, patch, negateXZ, false);
             }
         }
 
@@ -333,15 +335,15 @@ void Game::Render()
     const float fogend = 8;
 #endif
 
-    XMVECTORF32 red, blue, gray;
+    Vector4 red, blue, gray;
 #ifdef GAMMA_CORRECT_RENDERING
-    red.v = XMColorSRGBToRGB(Colors::Red);
-    blue.v = XMColorSRGBToRGB(Colors::Blue);
-    gray.v = XMColorSRGBToRGB(Colors::Gray);
+    red = XMColorSRGBToRGB(Colors::Red);
+    blue = XMColorSRGBToRGB(Colors::Blue);
+    gray = XMColorSRGBToRGB(Colors::Gray);
 #else
-    red.v = Colors::Red;
-    blue.v = Colors::Blue;
-    gray.v = Colors::Gray;
+    red = Colors::Red;
+    blue = Colors::Blue;
+    gray = Colors::Gray;
 #endif
 
     // Abstract effect
@@ -1038,7 +1040,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/EffectsTest/Game.h
+++ b/EffectsTest/Game.h
@@ -89,6 +89,11 @@ private:
     std::unique_ptr<DirectX::GraphicsMemory>    m_graphicsMemory;
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
+#endif
+
     template<typename T>
     class EffectWithDecl : public T
     {
@@ -103,7 +108,7 @@ private:
 
         void Apply(ID3D11DeviceContext* context, DirectX::CXMMATRIX world, DirectX::CXMMATRIX view, DirectX::CXMMATRIX projection)
         {
-            SetMatrices(world, view, projection);
+            T::SetMatrices(world, view, projection);
 
             T::Apply(context);
 
@@ -113,6 +118,10 @@ private:
     private:
         Microsoft::WRL::ComPtr<ID3D11InputLayout> inputLayout;
     };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
     std::unique_ptr<DirectX::CommonStates>                      m_states;
 

--- a/EffectsTest/pch.h
+++ b/EffectsTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 #include <DirectXPackedVector.h>

--- a/EmptyTest/pch.h
+++ b/EmptyTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/GamePadTest/Game.cpp
+++ b/GamePadTest/Game.cpp
@@ -31,8 +31,7 @@ using Microsoft::WRL::ComPtr;
 // Constructor.
 Game::Game() noexcept(false) :
     m_state{},
-    m_lastStr(nullptr),
-    m_lastStrBuff{}
+    m_lastStr(nullptr)
 {
 #ifdef GAMMA_CORRECT_RENDERING
     const DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
@@ -105,9 +104,6 @@ void Game::Initialize(
             MessageBoxW(window, L"GamePad not acting like a singleton", L"GamePadTest", MB_ICONERROR);
             throw std::exception("GamePad not acting like a singleton");
         }
-
-        auto state = GamePad::Get().GetState(0);
-        state;
     }
 #endif
 

--- a/GamePadTest/Game.h
+++ b/GamePadTest/Game.h
@@ -99,5 +99,4 @@ private:
     Microsoft::WRL::Wrappers::Event                 m_userChanged;
 
     const wchar_t *                                 m_lastStr;
-    wchar_t                                         m_lastStrBuff[128];
 };

--- a/GamePadTest/pch.h
+++ b/GamePadTest/pch.h
@@ -21,6 +21,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -29,6 +35,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -63,6 +73,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/HDRTest/Game.cpp
+++ b/HDRTest/Game.cpp
@@ -36,20 +36,20 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 c_BrightYellow = { 2.f, 2.f, 0.f, 1.f };
+    constexpr XMVECTORF32 c_BrightYellow = { { { 2.f, 2.f, 0.f, 1.f } } };
 
-    const XMVECTORF32 c_DimWhite = { .5f, .5f, .5f, 1.f };
-    const XMVECTORF32 c_BrightWhite = { 2.f, 2.f, 2.f, 1.f };
-    const XMVECTORF32 c_VeryBrightWhite = { 4.f, 4.f, 4.f, 1.f };
+    constexpr XMVECTORF32 c_DimWhite = { { { .5f, .5f, .5f, 1.f } } };
+    constexpr XMVECTORF32 c_BrightWhite = { { { 2.f, 2.f, 2.f, 1.f } } };
+    constexpr XMVECTORF32 c_VeryBrightWhite = { { { 4.f, 4.f, 4.f, 1.f } } };
 
-    const float row0 = -2.f;
+    constexpr float row0 = -2.f;
 
-    const float col0 = -5.f;
-    const float col1 = -3.5f;
-    const float col2 = -1.f;
-    const float col3 = 1.f;
-    const float col4 = 3.5f;
-    const float col5 = 5.f;
+    constexpr float col0 = -5.f;
+    constexpr float col1 = -3.5f;
+    constexpr float col2 = -1.f;
+    constexpr float col3 = 1.f;
+    constexpr float col4 = 3.5f;
+    constexpr float col5 = 5.f;
 }
 
 #ifdef XBOX
@@ -60,7 +60,7 @@ extern bool g_HDRMode;
 Game::Game() noexcept(false) :
     m_toneMapMode(ToneMapPostProcess::Reinhard)
 {
-#ifdef TEST_HDR_LINEAR
+#if defined(TEST_HDR_LINEAR) && !defined(XBOX)
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 #else
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
@@ -68,7 +68,7 @@ Game::Game() noexcept(false) :
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_D32_FLOAT, 2,
+        c_DisplayFormat, DXGI_FORMAT_D32_FLOAT, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -239,7 +239,6 @@ void Game::Render()
     float roll = time * 1.1f;
 
     XMMATRIX world = XMMatrixRotationRollPitchYaw(pitch, yaw, roll);
-    XMVECTOR quat = XMQuaternionRotationRollPitchYaw(pitch, yaw, roll);
 
     m_flatEffect->SetMatrices(world* XMMatrixTranslation(col0, row0, 0), m_view, m_projection);
     m_flatEffect->SetTexture(m_hdrImage1.Get());
@@ -488,7 +487,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 7 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 7.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;
@@ -553,7 +552,7 @@ void Game::CycleToneMapOperator()
 
     m_toneMapMode += 1;
 
-    if (m_toneMapMode >= ToneMapPostProcess::Operator_Max)
+    if (m_toneMapMode >= static_cast<int>(ToneMapPostProcess::Operator_Max))
     {
         m_toneMapMode = ToneMapPostProcess::Saturate;
     }

--- a/HDRTest/pch.h
+++ b/HDRTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -63,6 +73,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/KeyboardTest/Game.cpp
+++ b/KeyboardTest/Game.cpp
@@ -24,10 +24,10 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 START_POSITION = { 0.f, -1.5f, 0.f, 0.f };
-    const XMVECTORF32 ROOM_BOUNDS = { 8.f, 6.f, 12.f, 0.f };
+    constexpr XMVECTORF32 START_POSITION = { { { 0.f, -1.5f, 0.f, 0.f } } };
+    constexpr XMVECTORF32 ROOM_BOUNDS = { { { 8.f, 6.f, 12.f, 0.f } } };
 
-    const float MOVEMENT_GAIN = 0.07f;
+    constexpr float MOVEMENT_GAIN = 0.07f;
 }
 
 // Constructor.
@@ -114,9 +114,6 @@ void Game::Initialize(
             throw std::exception("Keyboard not acting like a singleton");
 #endif
         }
-
-        auto state = Keyboard::Get().GetState();
-        state;
     }
 
     OutputDebugStringA(m_keyboard->IsConnected() ? "INFO: Keyboard is connected\n" : "INFO: No keyboard found\n");

--- a/KeyboardTest/pch.h
+++ b/KeyboardTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/LoadTest/Game.cpp
+++ b/LoadTest/Game.cpp
@@ -41,7 +41,7 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    float dist = 10.f;
+    constexpr float dist = 10.f;
 
     bool ValidateDesc(
         ID3D11ShaderResourceView* srv,
@@ -468,7 +468,7 @@ void Game::Render()
         hr = SaveWICTextureToFile(context, backBufferTex, GUID_ContainerFormatTiff, sstif, nullptr,
             [&](IPropertyBag2* props)
         {
-            PROPBAG2 options[2] = { 0, 0 };
+            PROPBAG2 options[2] = {};
             options[0].pstrName = const_cast<wchar_t*>(L"CompressionQuality");
             options[1].pstrName = const_cast<wchar_t*>(L"TiffCompressionMethod");
 
@@ -903,9 +903,9 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 eyePosition = { 0.0f, 3.0f, -6.0f, 0.0f };
-    static const XMVECTORF32 At = { 0.0f, 1.0f, 0.0f, 0.0f };
-    static const XMVECTORF32 Up = { 0.0f, 1.0f, 0.0f, 0.0f };
+    static const XMVECTORF32 eyePosition = { { { 0.0f, 3.0f, -6.0f, 0.0f } } };
+    static const XMVECTORF32 At = { { { 0.0f, 1.0f, 0.0f, 0.0f } } };
+    static const XMVECTORF32 Up = { { { 0.0f, 1.0f, 0.0f, 0.0f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/LoadTest/pch.h
+++ b/LoadTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/ModelTest/Game.cpp
+++ b/ModelTest/Game.cpp
@@ -21,9 +21,9 @@
 
 namespace
 {
-    const float row0 = 2.f;
-    const float row1 = 0.f;
-    const float row2 = -2.f;
+    constexpr float row0 = 2.f;
+    constexpr float row1 = 0.f;
+    constexpr float row2 = -2.f;
 }
 
 extern void ExitGame() noexcept;
@@ -632,7 +632,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/ModelTest/pch.h
+++ b/ModelTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/MouseTest/Game.cpp
+++ b/MouseTest/Game.cpp
@@ -24,10 +24,8 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 START_POSITION = { 0.f, -1.5f, 0.f, 0.f };
-    const XMVECTORF32 ROOM_BOUNDS = { 8.f, 6.f, 12.f, 0.f };
-
-    const float MOVEMENT_GAIN = 0.07f;
+    constexpr XMVECTORF32 START_POSITION = { { { 0.f, -1.5f, 0.f, 0.f } } };
+    constexpr XMVECTORF32 ROOM_BOUNDS = { { { 8.f, 6.f, 12.f, 0.f } } };
 }
 
 // Constructor.
@@ -36,8 +34,7 @@ Game::Game() noexcept(false) :
     m_lastMode(Mouse::MODE_ABSOLUTE),
     m_pitch(0),
     m_yaw(0),
-    m_lastStr(nullptr),
-    m_lastStrBuff{}
+    m_lastStr(nullptr)
 {
     m_cameraPos = START_POSITION.v;
 
@@ -124,9 +121,6 @@ void Game::Initialize(
             throw std::exception("Mouse not acting like a singleton");
 #endif
         }
-
-        auto state = Mouse::Get().GetState();
-        state;
     }
 
     OutputDebugStringA(m_mouse->IsConnected() ? "INFO: Mouse is connected\n" : "INFO: No mouse found\n");
@@ -191,8 +185,8 @@ void Game::Update(DX::StepTimer const&)
 
     if (mouse.positionMode == Mouse::MODE_RELATIVE)
     {
-        static const XMVECTORF32 ROTATION_GAIN = { 0.004f, 0.004f, 0.f, 0.f };
-        XMVECTOR delta = XMVectorSet(float(mouse.x), float(mouse.y), 0.f, 0.f) * ROTATION_GAIN;
+        const SimpleMath::Vector4 ROTATION_GAIN(0.004f, 0.004f, 0.f, 0.f);
+        XMVECTOR delta = SimpleMath::Vector4(float(mouse.x), float(mouse.y), 0.f, 0.f) * ROTATION_GAIN;
 
         m_pitch -= XMVectorGetY(delta);
         m_yaw -= XMVectorGetX(delta);

--- a/MouseTest/Game.h
+++ b/MouseTest/Game.h
@@ -105,5 +105,4 @@ private:
     DirectX::SimpleMath::Matrix                         m_proj;
 
     const wchar_t *                                     m_lastStr;
-    wchar_t                                             m_lastStrBuff[128];
 };

--- a/MouseTest/pch.h
+++ b/MouseTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -37,6 +43,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -63,6 +73,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PBRModelTest/Game.cpp
+++ b/PBRModelTest/Game.cpp
@@ -40,11 +40,10 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 c_BrightYellow = { 2.f, 2.f, 0.f, 1.f };
+    const XMVECTORF32 c_BrightYellow = { { { 2.f, 2.f, 0.f, 1.f } } };
 
-    const float row0 = 1.5f;
-    const float row1 = 0.f;
-    const float row2 = -1.5f;
+    constexpr float row0 = 1.5f;
+    constexpr float row1 = -1.5f;
 }
 
 // Constructor.
@@ -55,7 +54,7 @@ Game::Game() noexcept(false) :
     m_pitch(0),
     m_yaw(0)
 {
-#ifdef TEST_HDR_LINEAR
+#if defined(TEST_HDR_LINEAR) && !defined(XBOX)
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 #else
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
@@ -63,7 +62,7 @@ Game::Game() noexcept(false) :
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_D32_FLOAT, 2,
+        c_DisplayFormat, DXGI_FORMAT_D32_FLOAT, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -357,7 +356,7 @@ void Game::Render()
 
     {
         XMMATRIX scale = XMMatrixScaling(0.75f, 0.75f, 0.75f);
-        XMMATRIX trans = XMMatrixTranslation(-2.5f, row2, 0.f);
+        XMMATRIX trans = XMMatrixTranslation(-2.5f, row1, 0.f);
         local = XMMatrixMultiply(scale, trans);
         local = XMMatrixMultiply(world, local);
     }
@@ -365,7 +364,7 @@ void Game::Render()
 
     {
         XMMATRIX scale = XMMatrixScaling(0.1f, 0.1f, 0.1f);
-        XMMATRIX trans = XMMatrixTranslation(1.5f, row2, 0.f);
+        XMMATRIX trans = XMMatrixTranslation(1.5f, row1, 0.f);
         local = XMMatrixMultiply(scale, trans);
         local = XMMatrixMultiply(world, local);
     }
@@ -616,7 +615,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;
@@ -687,7 +686,7 @@ void Game::CycleToneMapOperator()
 
     m_toneMapMode += 1;
 
-    if (m_toneMapMode >= ToneMapPostProcess::Operator_Max)
+    if (m_toneMapMode >= static_cast<int>(ToneMapPostProcess::Operator_Max))
     {
         m_toneMapMode = ToneMapPostProcess::Saturate;
     }

--- a/PBRModelTest/pch.h
+++ b/PBRModelTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -63,6 +73,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PBRTest/Game.cpp
+++ b/PBRTest/Game.cpp
@@ -41,21 +41,21 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 c_BrightYellow = { 2.f, 2.f, 0.f, 1.f };
+    constexpr XMVECTORF32 c_BrightYellow = { { { 2.f, 2.f, 0.f, 1.f } } };
 
-    const float col0 = -4.25f;
-    const float col1 = -3.f;
-    const float col2 = -1.75f;
-    const float col3 = -.6f;
-    const float col4 = .6f;
-    const float col5 = 1.75f;
-    const float col6 = 3.f;
-    const float col7 = 4.25f;
+    constexpr float col0 = -4.25f;
+    constexpr float col1 = -3.f;
+    constexpr float col2 = -1.75f;
+    constexpr float col3 = -.6f;
+    constexpr float col4 = .6f;
+    constexpr float col5 = 1.75f;
+    constexpr float col6 = 3.f;
+    constexpr float col7 = 4.25f;
 
-    const float row0 = 2.f;
-    const float row1 = 0.25f;
-    const float row2 = -1.1f;
-    const float row3 = -2.5f;
+    constexpr float row0 = 2.f;
+    constexpr float row1 = 0.25f;
+    constexpr float row2 = -1.1f;
+    constexpr float row3 = -2.5f;
 
     void ReadVBO(_In_z_ const wchar_t* name, std::vector<VertexPositionNormalTexture>& vertices, std::vector<uint16_t>& indices)
     {
@@ -70,7 +70,7 @@ namespace
             if (!inFile)
                 throw std::exception("ReadVBO");
 
-            if (len < sizeof(VBO::header_t))
+            if (len < static_cast<std::streampos>(sizeof(VBO::header_t)))
                 throw std::exception("ReadVBO");
 
             blob.resize(size_t(len));
@@ -123,7 +123,7 @@ Game::Game() noexcept(false) :
     m_pitch(0),
     m_yaw(0)
 {
-#ifdef TEST_HDR_LINEAR
+#if defined(TEST_HDR_LINEAR) && !defined(XBOX)
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 #else
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
@@ -131,7 +131,7 @@ Game::Game() noexcept(false) :
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_D32_FLOAT, 2,
+        c_DisplayFormat, DXGI_FORMAT_D32_FLOAT, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -1013,7 +1013,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;
@@ -1135,7 +1135,7 @@ void Game::CycleToneMapOperator()
 
     m_toneMapMode += 1;
 
-    if (m_toneMapMode >= ToneMapPostProcess::Operator_Max)
+    if (m_toneMapMode >= static_cast<int>(ToneMapPostProcess::Operator_Max))
     {
         m_toneMapMode = ToneMapPostProcess::Saturate;
     }

--- a/PBRTest/pch.h
+++ b/PBRTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -63,6 +73,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PostProcessTest/Game.cpp
+++ b/PostProcessTest/Game.cpp
@@ -28,8 +28,8 @@ namespace
     constexpr float ADVANCE_TIME = 1.f;
     constexpr float INTERACTIVE_TIME = 10.f;
 
-    const DXGI_FORMAT c_sdrFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
-    const DXGI_FORMAT c_hdrFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    constexpr DXGI_FORMAT c_sdrFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
+    constexpr DXGI_FORMAT c_hdrFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 }
 
 // Constructor.
@@ -859,7 +859,7 @@ void Game::ShaderTest()
 
     for (int j = 0; j < static_cast<int>(BasicPostProcess::Effect_Max); ++j)
     {
-        m_basicPostProcess->SetEffect( static_cast<BasicPostProcess::Effect>(j));
+        m_basicPostProcess->SetEffect(static_cast<BasicPostProcess::Effect>(j));
         m_basicPostProcess->Process(context);
     }
 

--- a/PostProcessTest/pch.h
+++ b/PostProcessTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PrimitivesTest/Game.cpp
+++ b/PrimitivesTest/Game.cpp
@@ -27,22 +27,22 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const float row0 = 2.7f;
-    const float row1 = 1.f;
-    const float row2 = -0.7f;
-    const float row3 = -2.5f;
+    constexpr float row0 = 2.7f;
+    constexpr float row1 = 1.f;
+    constexpr float row2 = -0.7f;
+    constexpr float row3 = -2.5f;
 
-    const float col0 = -7.5f;
-    const float col1 = -5.75f;
-    const float col2 = -4.25f;
-    const float col3 = -2.7f;
-    const float col4 = -1.25f;
-    const float col5 = 0.f;
-    const float col6 = 1.25f;
-    const float col7 = 2.5f;
-    const float col8 = 4.25f;
-    const float col9 = 5.75f;
-    const float col10 = 7.5f;
+    constexpr float col0 = -7.5f;
+    constexpr float col1 = -5.75f;
+    constexpr float col2 = -4.25f;
+    constexpr float col3 = -2.7f;
+    constexpr float col4 = -1.25f;
+    constexpr float col5 = 0.f;
+    constexpr float col6 = 1.25f;
+    constexpr float col7 = 2.5f;
+    constexpr float col8 = 4.25f;
+    constexpr float col9 = 5.75f;
+    constexpr float col10 = 7.5f;
 }
 
 Game::Game() noexcept(false) :
@@ -267,6 +267,7 @@ void Game::Render()
     lime.v = Colors::Lime;
     gray.v = Colors::Gray;
 #endif
+    SimpleMath::Vector4 white = Colors::White.v;
 
     //--- Draw shapes ----------------------------------------------------------------------
     m_cube->Draw(world * XMMatrixTranslation(col0, row0, 0), m_view, m_projection);
@@ -283,7 +284,7 @@ void Game::Render()
     m_box->Draw(world * XMMatrixTranslation(col8, row3, 0), m_view, m_projection, magenta);
 
     //--- Draw textured shapes -------------------------------------------------------------
-    m_cube->Draw(world * XMMatrixTranslation(col0, row1, 0), m_view, m_projection, Colors::White, m_reftxt.Get());
+    m_cube->Draw(world * XMMatrixTranslation(col0, row1, 0), m_view, m_projection, white, m_reftxt.Get());
     m_sphere->Draw(world * XMMatrixTranslation(col1, row1, 0), m_view, m_projection, red, m_reftxt.Get());
     m_geosphere->Draw(world * XMMatrixTranslation(col2, row1, 0), m_view, m_projection, green, m_reftxt.Get());
     m_cylinder->Draw(world * XMMatrixTranslation(col3, row1, 0), m_view, m_projection, lime, m_reftxt.Get());
@@ -295,7 +296,7 @@ void Game::Render()
     m_dodec->Draw(world * XMMatrixTranslation(col9, row1, 0), m_view, m_projection, blue, m_reftxt.Get());
     m_iso->Draw(world * XMMatrixTranslation(col10, row1, 0), m_view, m_projection, cyan, m_reftxt.Get());
     m_box->Draw(world * XMMatrixTranslation(col9, row3, 0), m_view, m_projection, magenta, m_reftxt.Get());
-    m_customBox->Draw(world * XMMatrixTranslation(col7, row3, 0), m_view, m_projection, Colors::White, m_reftxt.Get());
+    m_customBox->Draw(world * XMMatrixTranslation(col7, row3, 0), m_view, m_projection, white, m_reftxt.Get());
 
     //--- Draw shapes in wireframe ---------------------------------------------------------
     m_cube->Draw(world * XMMatrixTranslation(col0, row2, 0), m_view, m_projection, gray, nullptr, true);
@@ -312,11 +313,11 @@ void Game::Render()
     m_box->Draw(world * XMMatrixTranslation(col10, row3, 0), m_view, m_projection, gray, nullptr, true);
 
     //--- Draw shapes with alpha blending --------------------------------------------------
-    m_cube->Draw(world * XMMatrixTranslation(col0, row3, 0), m_view, m_projection, Colors::White * alphaFade);
-    m_cube->Draw(world * XMMatrixTranslation(col1, row3, 0), m_view, m_projection, Colors::White * alphaFade, m_cat.Get());
+    m_cube->Draw(world * XMMatrixTranslation(col0, row3, 0), m_view, m_projection, white * alphaFade);
+    m_cube->Draw(world * XMMatrixTranslation(col1, row3, 0), m_view, m_projection, white * alphaFade, m_cat.Get());
 
     //--- Draw shapes with custom device states --------------------------------------------
-    m_cube->Draw(world * XMMatrixTranslation(col2, row3, 0), m_view, m_projection, Colors::White * alphaFade, m_cat.Get(), false, [&]()
+    m_cube->Draw(world * XMMatrixTranslation(col2, row3, 0), m_view, m_projection, white * alphaFade, m_cat.Get(), false, [&]()
     {
         context->OMSetBlendState(m_states->NonPremultiplied(), Colors::White, 0xFFFFFFFF);
     });
@@ -531,7 +532,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 9 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 9.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/PrimitivesTest/pch.h
+++ b/PrimitivesTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/ShaderTest/Game.cpp
+++ b/ShaderTest/Game.cpp
@@ -28,8 +28,8 @@ namespace
     constexpr float SWAP_TIME = 1.f;
     constexpr float INTERACTIVE_TIME = 10.f;
 
-    const float ortho_width = 6.f;
-    const float ortho_height = 8.f;
+    constexpr float ortho_width = 6.f;
+    constexpr float ortho_height = 8.f;
 
     struct TestVertex
     {
@@ -38,7 +38,7 @@ namespace
             XMStoreFloat3(&this->position, position);
             XMStoreFloat3(&this->normal, normal);
             XMStoreFloat2(&this->textureCoordinate, textureCoordinate);
-            XMStoreFloat2(&this->textureCoordinate2, textureCoordinate * 3);
+            XMStoreFloat2(&this->textureCoordinate2, XMVectorScale(textureCoordinate, 3));
             XMStoreUByte4(&this->blendIndices, g_XMZero);
 
             XMStoreFloat3(&this->tangent, g_XMZero);
@@ -83,7 +83,7 @@ namespace
     void ComputeTangents(const IndexCollection& indices, VertexCollection& vertices)
     {
         static const float EPSILON = 0.0001f;
-        static const XMVECTORF32 s_flips = { 1.f, -1.f, -1.f, 1.f };
+        static const XMVECTORF32 s_flips = { { { 1.f, -1.f, -1.f, 1.f } } };
 
         size_t nFaces = indices.size() / 3;
         size_t nVerts = vertices.size();
@@ -216,13 +216,11 @@ namespace
             blendIndices = bn.blendIndices;
 
             XMVECTOR v = XMLoadFloat3(&bn.normal);
-            v = v * g_XMOneHalf;
-            v += g_XMOneHalf;
+            v = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
             XMStoreFloat3PK(&this->normal, v);
 
             v = XMLoadFloat3(&bn.tangent);
-            v = v * g_XMOneHalf;
-            v += g_XMOneHalf;
+            v = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
             XMStoreFloat3PK(&this->tangent, v);
 
             v = XMLoadFloat2(&bn.textureCoordinate);
@@ -292,20 +290,20 @@ namespace
 
         static const XMVECTORF32 faceNormals[FaceCount] =
         {
-            { 0,  0,  1 },
-            { 0,  0, -1 },
-            { 1,  0,  0 },
-            { -1,  0,  0 },
-            { 0,  1,  0 },
-            { 0, -1,  0 },
+            { { {  0,  0,  1, 0 } } },
+            { { {  0,  0, -1, 0 } }  },
+            { { {  1,  0,  0, 0 } }  },
+            { { { -1,  0,  0, 0 } }  },
+            { { {  0,  1,  0, 0 } }  },
+            { { {  0, -1,  0, 0 } }  },
         };
 
         static const XMVECTORF32 textureCoordinates[4] =
         {
-            { 1, 0 },
-            { 1, 1 },
-            { 0, 1 },
-            { 0, 0 },
+            { { { 1, 0, 0, 0 } } },
+            { { { 1, 1, 0, 0 } } },
+            { { { 0, 1, 0, 0 } } },
+            { { { 0, 0, 0, 0 } } },
         };
 
         static uint32_t colors[FaceCount]
@@ -318,18 +316,18 @@ namespace
             0xFF00FFFF,
         };
 
-        static const XMVECTORF32 tsize = { 0.25f, 0.25f, 0.25f, 0.f };
+        const Vector4 tsize(0.25f, 0.25f, 0.25f, 0.f);
 
         // Create each face in turn.
-        for (int i = 0; i < FaceCount; i++)
+        for (size_t i = 0; i < FaceCount; i++)
         {
-            XMVECTOR normal = faceNormals[i];
+            Vector4 normal = faceNormals[i].v;
 
             // Get two vectors perpendicular both to the face normal and to each other.
             XMVECTOR basis = (i >= 4) ? g_XMIdentityR2 : g_XMIdentityR1;
 
-            XMVECTOR side1 = XMVector3Cross(normal, basis);
-            XMVECTOR side2 = XMVector3Cross(normal, side1);
+            Vector4 side1 = XMVector3Cross(normal, basis);
+            Vector4 side2 = XMVector3Cross(normal, side1);
 
             // Six indices (two triangles) per face.
             size_t vbase = vertices.size();
@@ -1112,9 +1110,8 @@ void Game::CreateDeviceDependentResources()
     //--- BasicEffect ----------------------------------------------------------------------
 
     // BasicEffect (no texture)
-    m_basic.emplace_back(std::make_unique<EffectWithDecl<BasicEffect>>(device, [=](BasicEffect* effect)
+    m_basic.emplace_back(std::make_unique<EffectWithDecl<BasicEffect>>(device, [=](BasicEffect*)
     {
-        effect;
     }));
 
     m_basic.emplace_back(std::make_unique<EffectWithDecl<BasicEffect>>(device, [=](BasicEffect* effect)
@@ -2031,9 +2028,8 @@ void Game::CreateDeviceDependentResources()
     }
 
     //--- DebugEffect ----------------------------------------------------------------------
-    m_debug.emplace_back(std::make_unique<EffectWithDecl<DebugEffect>>(device, [=](DebugEffect* effect)
+    m_debug.emplace_back(std::make_unique<EffectWithDecl<DebugEffect>>(device, [=](DebugEffect*)
     {
-        effect;
     }));
 
     m_debug.emplace_back(std::make_unique<EffectWithDecl<DebugEffect>>(device, [=](DebugEffect* effect)
@@ -2077,9 +2073,8 @@ void Game::CreateDeviceDependentResources()
     //--- DGSLEffect -----------------------------------------------------------------------
 
     // DGSLEffect
-    m_dgsl.emplace_back(std::make_unique<DGSLEffectWithDecl<DGSLEffect>>(device, false, [=](DGSLEffect* effect)
+    m_dgsl.emplace_back(std::make_unique<DGSLEffectWithDecl<DGSLEffect>>(device, false, [=](DGSLEffect*)
     {
-        effect;
     }));
 
     m_dgsl.emplace_back(std::make_unique<DGSLEffectWithDecl<DGSLEffect>>(device, false, [=](DGSLEffect* effect)

--- a/ShaderTest/Game.cpp
+++ b/ShaderTest/Game.cpp
@@ -112,14 +112,14 @@ namespace
             XMVECTOR t1 = XMLoadFloat2(&vertices[i1].textureCoordinate);
             XMVECTOR t2 = XMLoadFloat2(&vertices[i2].textureCoordinate);
 
-            XMVECTOR s = XMVectorMergeXY(t1 - t0, t2 - t0);
+            XMVECTOR s = XMVectorMergeXY(XMVectorSubtract(t1, t0), XMVectorSubtract(t2, t0));
 
             XMFLOAT4A tmp;
             XMStoreFloat4A(&tmp, s);
 
             float d = tmp.x * tmp.w - tmp.z * tmp.y;
             d = (fabsf(d) <= EPSILON) ? 1.f : (1.f / d);
-            s *= d;
+            s = XMVectorScale(s, d);
             s = XMVectorMultiply(s, s_flips);
 
             XMMATRIX m0;
@@ -132,8 +132,8 @@ namespace
             XMVECTOR p2 = XMLoadFloat3(&vertices[i2].position);
 
             XMMATRIX m1;
-            m1.r[0] = p1 - p0;
-            m1.r[1] = p2 - p0;
+            m1.r[0] = XMVectorSubtract(p1, p0);
+            m1.r[1] = XMVectorSubtract(p2, p0);
             m1.r[2] = m1.r[3] = g_XMZero;
 
             XMMATRIX uv = XMMatrixMultiply(m0, m1);
@@ -154,11 +154,11 @@ namespace
             b0 = XMVector3Normalize(b0);
 
             XMVECTOR tan1 = tangent1[j];
-            XMVECTOR b1 = tan1 - XMVector3Dot(b0, tan1) * b0;
+            XMVECTOR b1 = XMVectorSubtract(tan1, XMVectorMultiply(XMVector3Dot(b0, tan1), b0));
             b1 = XMVector3Normalize(b1);
 
             XMVECTOR tan2 = tangent2[j];
-            XMVECTOR b2 = tan2 - XMVector3Dot(b0, tan2) * b0 - XMVector3Dot(b1, tan2) * b1;
+            XMVECTOR b2 = XMVectorSubtract(XMVectorSubtract(tan2, XMVectorMultiply(XMVector3Dot(b0, tan2), b0)), XMVectorMultiply(XMVector3Dot(b1, tan2), b1));
             b2 = XMVector3Normalize(b2);
 
             // handle degenerate vectors

--- a/ShaderTest/Game.h
+++ b/ShaderTest/Game.h
@@ -93,6 +93,11 @@ private:
     std::unique_ptr<DirectX::GraphicsMemory>    m_graphicsMemory;
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
+#endif
+
     template<typename T>
     class EffectWithDecl : public T
     {
@@ -107,7 +112,7 @@ private:
 
         void Apply(ID3D11DeviceContext* context, DirectX::CXMMATRIX world, DirectX::CXMMATRIX view, DirectX::CXMMATRIX projection, bool showCompressed)
         {
-            SetMatrices(world, view, projection);
+            T::SetMatrices(world, view, projection);
 
             auto ibasic = dynamic_cast<BasicEffect*>(this);
             if (ibasic)
@@ -157,7 +162,7 @@ private:
 
         void Apply(ID3D11DeviceContext* context, DirectX::CXMMATRIX world, DirectX::CXMMATRIX view, DirectX::CXMMATRIX projection)
         {
-            SetMatrices(world, view, projection);
+            T::SetMatrices(world, view, projection);
 
             T::Apply(context);
 
@@ -167,6 +172,10 @@ private:
     private:
         Microsoft::WRL::ComPtr<ID3D11InputLayout> inputLayout;
     };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
     std::unique_ptr<DirectX::CommonStates>  m_states;
 

--- a/ShaderTest/pch.h
+++ b/ShaderTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 #include <DirectXPackedVector.h>

--- a/SimpleAudioTest/Game.cpp
+++ b/SimpleAudioTest/Game.cpp
@@ -25,8 +25,8 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const unsigned int WB_INMEMORY_ENTRY = 8;
-    const unsigned int WB_STREAM_ENTRY = 1;
+    constexpr unsigned int WB_INMEMORY_ENTRY = 8;
+    constexpr unsigned int WB_STREAM_ENTRY = 1;
 
     const wchar_t* STREAM_NAMES[] =
     {
@@ -45,6 +45,9 @@ namespace
 
 SoundStreamInstance* Game::GetCurrentStream(unsigned int index)
 {
+    if (index >= _countof(STREAM_NAMES))
+        return nullptr;
+
 #ifdef TEST_XWMA
     if (index == 1)
     {
@@ -134,7 +137,7 @@ namespace
             }
             else
             {
-                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 };
+                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 } };
 
                 auto wfex = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(wfx);
 

--- a/SimpleAudioTest/pch.h
+++ b/SimpleAudioTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -37,6 +43,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -72,6 +82,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/SimpleMathTest/SimpleMathTest.cpp
+++ b/SimpleMathTest/SimpleMathTest.cpp
@@ -5461,8 +5461,6 @@ int TestL()
     maprct[Rectangle(10, 20, 0, 0)] = 4;
     maprct[Rectangle(0, 0, 0, 0)] = 1;
 
-    Rectangle ab(12, 20, 2, 2);
-
     mapv2[ Vector2(3.f, 2.f) ] = 4;
     mapv2[ Vector2(1.f, 2.f) ] = 1;
     mapv2[ Vector2(2.f, 2.f) ] = 3;

--- a/SpriteBatchTest/pch.h
+++ b/SpriteBatchTest/pch.h
@@ -29,6 +29,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +42,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/SpriteFontTest/Game.cpp
+++ b/SpriteFontTest/Game.cpp
@@ -24,9 +24,9 @@
 
 namespace
 {
-    const float SWAP_TIME = 3.f;
+    constexpr float SWAP_TIME = 3.f;
 
-    const float EPSILON = 0.000001f;
+    constexpr float EPSILON = 0.000001f;
 }
 
 extern void ExitGame() noexcept;
@@ -233,7 +233,7 @@ void Game::Render()
         SpriteEffects flip = (SpriteEffects)((int)(time / 100) & 3);
         m_multicoloredFont->DrawString(m_spriteBatch.get(), "OMG it's full of stars!", XMFLOAT2(610, 130), Colors::White, XM_PIDIV2, XMFLOAT2(0, 0), 1, flip);
 
-        m_comicFont->DrawString(m_spriteBatch.get(), u8"This is a larger block\nof text using a\nfont scaled to a\nsmaller size.\nSome c\x1234ha\x1543rac\x2453te\x1634r\x1563s are not in the font, but should show up as hyphens.", XMFLOAT2(10, 90), Colors::Black, 0, XMFLOAT2(0, 0), 0.5f);
+        m_comicFont->DrawString(m_spriteBatch.get(), u8"This is a larger block\nof text using a\nfont scaled to a\nsmaller size.\nSome c\xffha\xferac\xfdte\xffr\xfas are not in the font, but should show up as hyphens.", XMFLOAT2(10, 90), Colors::Black, 0, XMFLOAT2(0, 0), 0.5f);
 
         char tmp[256] = {};
         sprintf_s(tmp, "%llu frames", m_frame);
@@ -244,17 +244,17 @@ void Game::Render()
 
         float scale = sin(time / 100) + 1;
         auto spinText = "Spinning\nlike a cat";
-        auto size = m_comicFont->MeasureString(spinText);
-        m_comicFont->DrawString(m_spriteBatch.get(), spinText, XMVectorSet(150, 350, 0, 0), blue, time / 60, size / 2, scale);
+        Vector2 size = m_comicFont->MeasureString(spinText);
+        m_comicFont->DrawString(m_spriteBatch.get(), spinText, Vector2(150, 350), blue, time / 60, size / 2, scale);
 
         auto mirrorText = "It's a\nmirror...";
-        auto mirrorSize = m_comicFont->MeasureString(mirrorText);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), Colors::Black, 0, mirrorSize * XMVectorSet(0, 1, 0, 0), 1, SpriteEffects_None);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(1, 1, 0, 0), 1, SpriteEffects_FlipHorizontally);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), dgray, 0, mirrorSize * XMVectorSet(1, 0, 0, 0), 1, SpriteEffects_FlipBoth);
+        Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), Colors::Black, 0, mirrorSize * Vector2(0, 1), 1, SpriteEffects_None);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(1, 1), 1, SpriteEffects_FlipHorizontally);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(0, 0), 1, SpriteEffects_FlipVertically);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), dgray, 0, mirrorSize * Vector2(1, 0), 1, SpriteEffects_FlipBoth);
 
-        m_japaneseFont->DrawString(m_spriteBatch.get(), u8"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
+        m_japaneseFont->DrawString(m_spriteBatch.get(), L"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
     }
     else
     {
@@ -276,15 +276,15 @@ void Game::Render()
 
         float scale = sin(time / 100) + 1;
         auto spinText = L"Spinning\nlike a cat";
-        auto size = m_comicFont->MeasureString(spinText);
-        m_comicFont->DrawString(m_spriteBatch.get(), spinText, XMVectorSet(150, 350, 0, 0), blue, time / 60, size / 2, scale);
+        Vector2 size = m_comicFont->MeasureString(spinText);
+        m_comicFont->DrawString(m_spriteBatch.get(), spinText, Vector2(150, 350), blue, time / 60, size / 2, scale);
 
         auto mirrorText = L"It's a\nmirror...";
-        auto mirrorSize = m_comicFont->MeasureString(mirrorText);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), Colors::Black, 0, mirrorSize * XMVectorSet(0, 1, 0, 0), 1, SpriteEffects_None);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(1, 1, 0, 0), 1, SpriteEffects_FlipHorizontally);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), dgray, 0, mirrorSize * XMVectorSet(1, 0, 0, 0), 1, SpriteEffects_FlipBoth);
+        Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), Colors::Black, 0, mirrorSize * Vector2(0, 1), 1, SpriteEffects_None);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(1, 1), 1, SpriteEffects_FlipHorizontally);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(0, 0), 1, SpriteEffects_FlipVertically);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), dgray, 0, mirrorSize * Vector2(1, 0), 1, SpriteEffects_FlipBoth);
 
         m_japaneseFont->DrawString(m_spriteBatch.get(), L"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
     }

--- a/SpriteFontTest/pch.h
+++ b/SpriteFontTest/pch.h
@@ -29,6 +29,17 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -36,6 +47,10 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +77,7 @@
 #endif
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/StreamingAudioTest/StreamingAudioTest.cpp
+++ b/StreamingAudioTest/StreamingAudioTest.cpp
@@ -82,20 +82,20 @@ namespace
         {
             if (wfx->cbSize < (sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)))
             {
-                printf("\tEXTENSIBLE, %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                printf("\tEXTENSIBLE, %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                     wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
                 printf("\tERROR: Invalid WAVE_FORMAT_EXTENSIBLE\n");
             }
             else
             {
-                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 };
+                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 } };
 
                 auto wfex = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(wfx);
 
                 if (memcmp(reinterpret_cast<const BYTE*>(&wfex->SubFormat) + sizeof(DWORD),
                     reinterpret_cast<const BYTE*>(&s_wfexBase) + sizeof(DWORD), sizeof(GUID) - sizeof(DWORD)) != 0)
                 {
-                    printf("\tEXTENSIBLE, %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                    printf("\tEXTENSIBLE, %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                         wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
                     printf("\tERROR: Unknown EXTENSIBLE SubFormat {%8.8lX-%4.4X-%4.4X-%2.2X%2.2X-%2.2X%2.2X%2.2X%2.2X%2.2X%2.2X}\n",
                         wfex->SubFormat.Data1, wfex->SubFormat.Data2, wfex->SubFormat.Data3,
@@ -104,17 +104,17 @@ namespace
                 }
                 else
                 {
-                    printf("\tEXTENSIBLE %s (%u), %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+                    printf("\tEXTENSIBLE %s (%lu), %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                         GetFormatTagName(wfex->SubFormat.Data1), wfex->SubFormat.Data1,
                         wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
-                    printf("\t\t%u samples per block, %u valid bps, %u channel mask",
+                    printf("\t\t%u samples per block, %u valid bps, %lu channel mask",
                         wfex->Samples.wSamplesPerBlock, wfex->Samples.wValidBitsPerSample, wfex->dwChannelMask);
                 }
             }
         }
         else
         {
-            printf("\t%s (%u), %u channels, %u-bit, %u Hz, %u align, %u avg\n",
+            printf("\t%s (%u), %u channels, %u-bit, %lu Hz, %u align, %lu avg\n",
                 GetFormatTagName(wfx->wFormatTag), wfx->wFormatTag,
                 wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, wfx->nBlockAlign, wfx->nAvgBytesPerSec);
         }
@@ -178,7 +178,7 @@ int __cdecl main()
         default:                        speakerConfig = "(unknown)"; break;
         }
 
-        printf("\tOutput format rate %u, channels %u, %s (%08X)\n", output.Format.nSamplesPerSec, output.Format.nChannels, speakerConfig, output.dwChannelMask);
+        printf("\tOutput format rate %lu, channels %u, %s (%08lX)\n", output.Format.nSamplesPerSec, output.Format.nChannels, speakerConfig, output.dwChannelMask);
     }
 
     if (!audEngine->IsAudioDevicePresent())

--- a/fuzzloaders/fuzzloaders.cpp
+++ b/fuzzloaders/fuzzloaders.cpp
@@ -108,7 +108,9 @@ const SValue g_pOptions [] =
 
 namespace
 {
+#ifdef _PREFAST_
 #pragma prefast(disable : 26018, "Only used with static internal arrays")
+#endif
 
     DWORD LookupByName(const wchar_t *pName, const SValue *pArray)
     {
@@ -121,19 +123,6 @@ namespace
         }
 
         return 0;
-    }
-
-    const wchar_t* LookupByValue(DWORD pValue, const SValue *pArray)
-    {
-        while (pArray->pName)
-        {
-            if (pValue == pArray->dwValue)
-                return pArray->pName;
-
-            pArray++;
-        }
-
-        return L"";
     }
 
     void SearchForFiles(const wchar_t* path, std::list<SConversion>& files, bool recursive)
@@ -261,7 +250,9 @@ HRESULT CreateDevice(ID3D11Device** pDev, ID3D11DeviceContext** pContext)
 //--------------------------------------------------------------------------------------
 // Entry-point
 //--------------------------------------------------------------------------------------
+#ifdef _PREFAST_
 #pragma prefast(disable : 28198, "Command-line tool, frees all memory on exit")
+#endif
 
 int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
 {


### PR DESCRIPTION
Mostly changes related to using ``_XM_NO_XMVECTOR_OVERLOADS_`` for DirectXMath, plus some warnings