### PR TITLE
Input refactoring and cleanup

### DIFF
--- a/Common/DeviceResourcesXDK.cpp
+++ b/Common/DeviceResourcesXDK.cpp
@@ -76,7 +76,6 @@ void DeviceResources::CreateDeviceResources()
 
     if (m_options & c_Enable4K_UHD)
     {
-#if _XDK_VER >= 0x3F6803F3 /* XDK Edition 170600 */
         D3D11X_GPU_HARDWARE_CONFIGURATION hwConfig = {};
         m_d3dDevice->GetGpuHardwareConfiguration(&hwConfig);
         if (hwConfig.HardwareVersion >= D3D11X_HARDWARE_VERSION_XBOX_ONE_X)
@@ -97,7 +96,6 @@ void DeviceResources::CreateDeviceResources()
         m_options &= ~c_Enable4K_UHD;
 #ifdef _DEBUG
         OutputDebugStringA("WARNING: Hardware detection not supported on this XDK edition; Swapchain using 1080p (1920 x 1080)\n");
-#endif
 #endif
     }
 }

--- a/Common/MainPC.cpp
+++ b/Common/MainPC.cpp
@@ -244,6 +244,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         }
         break;
 
+    case WM_ACTIVATE:
+        Keyboard::ProcessMessage(message, wParam, lParam);
+        Mouse::ProcessMessage(message, wParam, lParam);
+        break;
+
     case WM_POWERBROADCAST:
         switch (wParam)
         {
@@ -307,7 +312,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         Keyboard::ProcessMessage(message, wParam, lParam);
         break;
 
-    case WM_ACTIVATE:
     case WM_INPUT:
     case WM_MOUSEMOVE:
     case WM_LBUTTONDOWN:

--- a/MouseTest/Game.cpp
+++ b/MouseTest/Game.cpp
@@ -95,9 +95,7 @@ void Game::Initialize(
     m_deviceResources->SetWindow(window);
 #ifdef COREWINDOW
     m_keyboard->SetWindow(reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(window));
-#if _XDK_VER >= 0x42D907D1
     m_mouse->SetWindow(reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(window));
-#endif
 #endif
 #elif defined(UWP)
     m_deviceResources->SetWindow(window, width, height, rotation);


### PR DESCRIPTION
* Legacy Xbox One XDK support now requires April 2018, May 2018, or June 2018.