### PR TITLE
Retire VS 2019 UWP projects

### DIFF
--- a/AnimTest/AnimTest_Windows10.vcxproj
+++ b/AnimTest/AnimTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -322,7 +322,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/Audio3DTest/Audio3DTest_Windows10.vcxproj
+++ b/Audio3DTest/Audio3DTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -284,7 +284,7 @@
     <Image Include="..\Common\WideLogo.scale-100.png" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/D3D11Test/D3D11Test_Windows10.vcxproj
+++ b/D3D11Test/D3D11Test_Windows10.vcxproj
@@ -102,28 +102,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -254,7 +254,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/DGSLTest/DGSLTest_Windows10.vcxproj
+++ b/DGSLTest/DGSLTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -353,7 +353,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/DirectXTK_Tests_Windows10.sln
+++ b/DirectXTK_Tests_Windows10.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.33927.289
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTK", "..\DirectXTK_Windows10_2019.vcxproj", "{F4776924-619C-42C7-88B2-82C947CCC9E7}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTK", "..\DirectXTK_Windows10_2022.vcxproj", "{F4776924-619C-42C7-88B2-82C947CCC9E7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Graphics", "Graphics", "{91743623-2C82-4825-B518-60470957082D}"
 EndProject

--- a/EffectsTest/EffectsTest_Windows10.vcxproj
+++ b/EffectsTest/EffectsTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -280,7 +280,7 @@
     <Image Include="spnza_bricks_a_specular.DDS" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/GamePadTest/GamePadTest_Windows10.vcxproj
+++ b/GamePadTest/GamePadTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -279,7 +279,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/HDRTest/HDRTest_Windows10.vcxproj
+++ b/HDRTest/HDRTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -269,7 +269,7 @@
     <AppxManifest Include="PackageUWP.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/KeyboardTest/KeyboardTest_Windows10.vcxproj
+++ b/KeyboardTest/KeyboardTest_Windows10.vcxproj
@@ -102,28 +102,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -262,7 +262,7 @@
     <Image Include="texture.dds" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/LoadTest/LoadTest_Windows10.vcxproj
+++ b/LoadTest/LoadTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -286,7 +286,7 @@
     <Image Include="win95.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/ModelTest/ModelTest_Windows10.vcxproj
+++ b/ModelTest/ModelTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -403,7 +403,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/MouseTest/MouseTest_Windows10.vcxproj
+++ b/MouseTest/MouseTest_Windows10.vcxproj
@@ -102,28 +102,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -263,7 +263,7 @@
     <Image Include="texture.dds" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/PBRModelTest/PBRModelTest_Windows10.vcxproj
+++ b/PBRModelTest/PBRModelTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Link>
@@ -265,7 +265,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/PBRTest/PBRTest_Windows10.vcxproj
+++ b/PBRTest/PBRTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -263,7 +263,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/PostProcessTest/PostProcessTest_Windows10.vcxproj
+++ b/PostProcessTest/PostProcessTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -276,7 +276,7 @@
     <Image Include="sunset.jpg" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/PrimitivesTest/PrimitivesTest_Windows10.vcxproj
+++ b/PrimitivesTest/PrimitivesTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -275,7 +275,7 @@
     <AppxManifest Include="PackageUWP.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/ShaderTest/ShaderTest_Windows10.vcxproj
+++ b/ShaderTest/ShaderTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -263,7 +263,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/SimpleAudioTest/SimpleAudioTest_Windows10.vcxproj
+++ b/SimpleAudioTest/SimpleAudioTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -334,7 +334,7 @@
     <AppxManifest Include="PackageUWP.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/SpriteBatchTest/SpriteBatchTest_Windows10.vcxproj
+++ b/SpriteBatchTest/SpriteBatchTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -275,7 +275,7 @@
     <AppxManifest Include="PackageUWP.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/SpriteFontTest/SpriteFontTest_Windows10.vcxproj
+++ b/SpriteFontTest/SpriteFontTest_Windows10.vcxproj
@@ -101,28 +101,28 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Windows10_2019\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Windows10_2022\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
@@ -345,7 +345,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DirectXTK_Windows10_2019.vcxproj">
+    <ProjectReference Include="..\..\DirectXTK_Windows10_2022.vcxproj">
       <Project>{f4776924-619c-42c7-88b2-82c947ccc9e7}</Project>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Updates all the UWP tests to use VS 2022 version of libs