### PR TITLE
Retire support for Direct3D 9.x Feature Levels

### DIFF
--- a/AnimTest/Game.cpp
+++ b/AnimTest/Game.cpp
@@ -73,10 +73,11 @@ Game::Game() noexcept(false)
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -84,11 +85,11 @@ Game::Game() noexcept(false)
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/Audio3DTest/Game.cpp
+++ b/Audio3DTest/Game.cpp
@@ -117,10 +117,11 @@ Game::Game() noexcept(false) :
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -128,11 +129,11 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/Common/DeviceResourcesUWP.cpp
+++ b/Common/DeviceResourcesUWP.cpp
@@ -264,9 +264,6 @@ void DeviceResources::CreateDeviceResources()
         D3D_FEATURE_LEVEL_11_0,
         D3D_FEATURE_LEVEL_10_1,
         D3D_FEATURE_LEVEL_10_0,
-        D3D_FEATURE_LEVEL_9_3,
-        D3D_FEATURE_LEVEL_9_2,
-        D3D_FEATURE_LEVEL_9_1,
     };
 
     UINT featLevelCount = 0;

--- a/Common/DeviceResourcesUWP.h
+++ b/Common/DeviceResourcesUWP.h
@@ -26,9 +26,9 @@ namespace DX
         static constexpr unsigned int c_EnableQHD_Xbox = 0x8;
 
         DeviceResources(DXGI_FORMAT backBufferFormat = DXGI_FORMAT_B8G8R8A8_UNORM,
-                        DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D24_UNORM_S8_UINT,
+                        DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D32_FLOAT,
                         UINT backBufferCount = 2,
-                        D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL_9_3,
+                        D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL_10_0,
                         unsigned int flags = 0) noexcept;
         ~DeviceResources() = default;
 

--- a/D3D11Test/Game.cpp
+++ b/D3D11Test/Game.cpp
@@ -46,10 +46,11 @@ Game::Game() noexcept(false)
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -57,11 +58,11 @@ Game::Game() noexcept(false)
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE
@@ -103,9 +104,9 @@ void Game::Initialize(
 #ifdef _DEBUG
     switch (m_deviceResources->GetDeviceFeatureLevel())
     {
-    case D3D_FEATURE_LEVEL_9_1: OutputDebugStringA("INFO: Direct3D Hardware Feature level 9.1\n"); break;
-    case D3D_FEATURE_LEVEL_9_2: OutputDebugStringA("INFO: Direct3D Hardware Feature level 9.2\n"); break;
-    case D3D_FEATURE_LEVEL_9_3: OutputDebugStringA("INFO: Direct3D Hardware Feature level 9.3\n"); break;
+    case D3D_FEATURE_LEVEL_9_1: OutputDebugStringA("INFO: Direct3D Hardware Feature level 9.1 [NOT SUPPORTED]\n"); break;
+    case D3D_FEATURE_LEVEL_9_2: OutputDebugStringA("INFO: Direct3D Hardware Feature level 9.2 [NOT SUPPORTED]\n"); break;
+    case D3D_FEATURE_LEVEL_9_3: OutputDebugStringA("INFO: Direct3D Hardware Feature level 9.3 [NOT SUPPORTED]\n"); break;
     case D3D_FEATURE_LEVEL_10_0: OutputDebugStringA("INFO: Direct3D Hardware Feature level 10.0\n"); break;
     case D3D_FEATURE_LEVEL_10_1: OutputDebugStringA("INFO: Direct3D Hardware Feature level 10.1\n"); break;
     case D3D_FEATURE_LEVEL_11_0: OutputDebugStringA("INFO: Direct3D Hardware Feature level 11.0\n"); break;

--- a/DGSLTest/Game.cpp
+++ b/DGSLTest/Game.cpp
@@ -18,9 +18,6 @@
 // Build for LH vs. RH coords
 //#define LH_COORDS
 
-// Build FL 10.0 vs. 9.1
-//#define FEATURE_LEVEL_9_X
-
 extern void ExitGame() noexcept;
 
 using namespace DirectX;
@@ -51,10 +48,11 @@ Game::Game() noexcept(false)
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -62,21 +60,11 @@ Game::Game() noexcept(false)
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-#ifdef FEATURE_LEVEL_9_X
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
-#else
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2, D3D_FEATURE_LEVEL_10_0,
-#endif
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
-#elif defined(FEATURE_LEVEL_9_X)
-    m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3
-        );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2, D3D_FEATURE_LEVEL_10_0
-        );
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/GamePadTest/Game.cpp
+++ b/GamePadTest/Game.cpp
@@ -92,7 +92,7 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else

--- a/KeyboardTest/Game.cpp
+++ b/KeyboardTest/Game.cpp
@@ -77,10 +77,11 @@ Game::Game() noexcept(false) :
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -88,11 +89,11 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/LoadTest/Game.cpp
+++ b/LoadTest/Game.cpp
@@ -189,10 +189,11 @@ Game::Game() noexcept(false) :
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -200,11 +201,11 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/ModelTest/Game.cpp
+++ b/ModelTest/Game.cpp
@@ -61,10 +61,11 @@ Game::Game() noexcept(false) :
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -72,11 +73,11 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE
@@ -265,7 +266,6 @@ void Game::Render()
 
     Clear();
 
-    auto device = m_deviceResources->GetD3DDevice();
     auto context = m_deviceResources->GetD3DDeviceContext();
 
 #ifdef LH_COORDS
@@ -375,7 +375,6 @@ void Game::Render()
     }
 
         // Custom drawing using instancing
-    if (device->GetFeatureLevel() >= D3D_FEATURE_LEVEL_9_3)
     {
         {
             size_t j = 0;

--- a/MouseTest/Game.cpp
+++ b/MouseTest/Game.cpp
@@ -71,10 +71,11 @@ Game::Game() noexcept(false) :
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -82,11 +83,11 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/PrimitivesTest/Game.cpp
+++ b/PrimitivesTest/Game.cpp
@@ -66,10 +66,11 @@ Game::Game() noexcept(false) :
 #else
     constexpr DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 #endif
+    constexpr DXGI_FORMAT c_DepthFormat = DXGI_FORMAT_D32_FLOAT;
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D32_FLOAT, 2,
+        c_RenderFormat, c_DepthFormat, 2,
         DX::DeviceResources::c_Enable4K_UHD
 #ifdef USE_FAST_SEMANTICS
         | DX::DeviceResources::c_FastSemantics
@@ -77,11 +78,11 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_D24_UNORM_S8_UINT, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, c_DepthFormat, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else
-    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat);
+    m_deviceResources = std::make_unique<DX::DeviceResources>(c_RenderFormat, c_DepthFormat);
 #endif
 
 #ifdef LOSTDEVICE

--- a/SimpleAudioTest/Game.cpp
+++ b/SimpleAudioTest/Game.cpp
@@ -239,7 +239,7 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else

--- a/SpriteBatchTest/Game.cpp
+++ b/SpriteBatchTest/Game.cpp
@@ -63,7 +63,7 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else

--- a/SpriteFontTest/Game.cpp
+++ b/SpriteFontTest/Game.cpp
@@ -64,7 +64,7 @@ Game::Game() noexcept(false) :
         );
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_9_3,
+        c_RenderFormat, DXGI_FORMAT_UNKNOWN, 2, D3D_FEATURE_LEVEL_10_0,
         DX::DeviceResources::c_Enable4K_Xbox | DX::DeviceResources::c_EnableQHD_Xbox
         );
 #else


### PR DESCRIPTION
Feature Level 9.x was already removed from desktop implementations. It was just in the UWP tests, and is no longer needed.